### PR TITLE
[bugfix] Spring doc 의존성 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
-	implementation 'org.springdoc:springdoc-openapi-ui:2.6.0'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	// springdoc 의존성 수정
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-common:2.2.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'


### PR DESCRIPTION
- CI/CD 구축 중 테스트 배포에서 발생한 빌드 문제
- 이는 Spring docs 버전이 호환되지 않는 문제였고 이를 해결하기 위한 의존성 설정 수정 #17 